### PR TITLE
chore(cloudsdk): bump version to 564.0.0

### DIFF
--- a/google-cloud-cli-firestore-emulator/.SRCINFO
+++ b/google-cloud-cli-firestore-emulator/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = google-cloud-cli-firestore-emulator
 	pkgdesc = A google-cloud-cli component that provides a local, in-memory emulator for Firestore.
-	pkgver = 558.0.0
+	pkgver = 564.0.0
 	pkgrel = 1
 	url = https://cloud.google.com/firestore/docs/emulator
 	arch = x86_64
@@ -8,7 +8,7 @@ pkgbase = google-cloud-cli-firestore-emulator
 	depends = google-cloud-cli
 	depends = java-runtime
 	options = !strip
-	source = https://dl.google.com/dl/cloudsdk/release/downloads/for_packagers/linux/google-cloud-cli-firestore-emulator_558.0.0.orig.tar.gz
-	sha256sums = 8b20fc751ab3aaada66ed4309838dc70838027a278ba921960616580cc15618b
+	source = https://dl.google.com/dl/cloudsdk/release/downloads/for_packagers/linux/google-cloud-cli-firestore-emulator_564.0.0.orig.tar.gz
+	sha256sums = f05288f74d3a3f18933e7d3758fbdfe3d286f5cb0b8078640021c4ce20a823b6
 
 pkgname = google-cloud-cli-firestore-emulator

--- a/google-cloud-cli-firestore-emulator/PKGBUILD
+++ b/google-cloud-cli-firestore-emulator/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Sebastian Kunze <mail at sebastiankunze dot de>
 
 pkgname=google-cloud-cli-firestore-emulator
-pkgver=558.0.0
+pkgver=564.0.0
 pkgrel=1
 pkgdesc='A google-cloud-cli component that provides a local, in-memory emulator for Firestore.'
 arch=('x86_64')
@@ -10,7 +10,7 @@ license=('Apache-2.0')
 depends=('google-cloud-cli' 'java-runtime')
 options=('!strip')
 source=("https://dl.google.com/dl/cloudsdk/release/downloads/for_packagers/linux/${pkgname}_${pkgver}.orig.tar.gz")
-sha256sums=('8b20fc751ab3aaada66ed4309838dc70838027a278ba921960616580cc15618b')
+sha256sums=('f05288f74d3a3f18933e7d3758fbdfe3d286f5cb0b8078640021c4ce20a823b6')
 
 package() {
     cd "$srcdir/google-cloud-sdk"  # Does not match naming convention google-cloud-cli


### PR DESCRIPTION
Automated version bump to 564.0.0