### PR TITLE
chore(cloudsdk): bump version to 566.0.0

### DIFF
--- a/google-cloud-cli-firestore-emulator/.SRCINFO
+++ b/google-cloud-cli-firestore-emulator/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = google-cloud-cli-firestore-emulator
 	pkgdesc = A google-cloud-cli component that provides a local, in-memory emulator for Firestore.
-	pkgver = 565.0.0
+	pkgver = 566.0.0
 	pkgrel = 1
 	url = https://cloud.google.com/firestore/docs/emulator
 	arch = x86_64
@@ -8,7 +8,7 @@ pkgbase = google-cloud-cli-firestore-emulator
 	depends = google-cloud-cli
 	depends = java-runtime
 	options = !strip
-	source = https://dl.google.com/dl/cloudsdk/release/downloads/for_packagers/linux/google-cloud-cli-firestore-emulator_565.0.0.orig.tar.gz
-	sha256sums = 91e1389cd5428f21c424661a12123f378bb260ffc3a03494b2236f4a22956eb5
+	source = https://dl.google.com/dl/cloudsdk/release/downloads/for_packagers/linux/google-cloud-cli-firestore-emulator_566.0.0.orig.tar.gz
+	sha256sums = 3bf0d15150e33e107e27b971a91569bac66971dbf586c55e50a93cdab665da3e
 
 pkgname = google-cloud-cli-firestore-emulator

--- a/google-cloud-cli-firestore-emulator/PKGBUILD
+++ b/google-cloud-cli-firestore-emulator/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Sebastian Kunze <mail at sebastiankunze dot de>
 
 pkgname=google-cloud-cli-firestore-emulator
-pkgver=565.0.0
+pkgver=566.0.0
 pkgrel=1
 pkgdesc='A google-cloud-cli component that provides a local, in-memory emulator for Firestore.'
 arch=('x86_64')
@@ -10,7 +10,7 @@ license=('Apache-2.0')
 depends=('google-cloud-cli' 'java-runtime')
 options=('!strip')
 source=("https://dl.google.com/dl/cloudsdk/release/downloads/for_packagers/linux/${pkgname}_${pkgver}.orig.tar.gz")
-sha256sums=('91e1389cd5428f21c424661a12123f378bb260ffc3a03494b2236f4a22956eb5')
+sha256sums=('3bf0d15150e33e107e27b971a91569bac66971dbf586c55e50a93cdab665da3e')
 
 package() {
     cd "$srcdir/google-cloud-sdk"  # Does not match naming convention google-cloud-cli


### PR DESCRIPTION
Automated version bump to 566.0.0